### PR TITLE
Required changes to get the cloud provided development cluster.

### DIFF
--- a/infrastructure/k8s/authentication-depl.yaml
+++ b/infrastructure/k8s/authentication-depl.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: authentication
-          image: pranshu72001/eventhive-authentication
+          image: us.gcr.io/eventhive-dev/authentication
 ---
 apiVersion: v1
 kind: Service

--- a/infrastructure/k8s/ingress-srv.yaml
+++ b/infrastructure/k8s/ingress-srv.yaml
@@ -11,7 +11,7 @@ spec:
       http:
         paths:
           - path: /api/users/?(.*)
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: authentication-srv

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,10 +4,12 @@ manifests:
   rawYaml:
     - ./infrastructure/k8s/*
 build:
-  local:
-    push: false
+  # local:
+  #   push: false
+  googleCloudBuild:
+    projectId: eventhive-dev
   artifacts:
-    - image: pranshu72001/eventhive-authentication
+    - image: us.gcr.io/eventhive-dev/authentication
       context: authentication
       docker:
         dockerfile: Dockerfile


### PR DESCRIPTION
This changes were needed to successfully build using the google cloud provider service.

Apart from the changes in the review, I had to do the following:

- Create a project on Google cloud console.
- Create a cluster with N1(gSmall) default configuration.
- Install the google cloud sdk
- Initialise the SDK to work for the current project.
- The kubernetes context has shifted to the cloud provided cluster.
- Installed ingress-nginx in that cluster.
- Updated the /etc/hosts file to use the cloud provided load balancer endpoint instead of local host.