### PR TITLE
Integrate the nats client to the tickets service.

### DIFF
--- a/authentication/package-lock.json
+++ b/authentication/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@eventhive/common": "^1.0.6",
+        "@eventhive/common": "^1.0.8",
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@eventhive/common": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.6.tgz",
-      "integrity": "sha512-1HgEURHUc8ASXogLM2ANuO3RfJIuMyDXkuaOFyMNsnbGWdMA56o+T/nMUq3HNhUYoxtMYnsdbWSLg4CWGteJLg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.8.tgz",
+      "integrity": "sha512-GNKO9pUsmYQfUfd4ZtiB/WshnJKtOQWBm8cnvXzek1UB/9HWW/RM1zYh7fqKZPqPFR8ECZveIUDlot6i+90hag==",
       "dependencies": {
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",

--- a/authentication/package.json
+++ b/authentication/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@eventhive/common": "^1.0.6",
+    "@eventhive/common": "^1.0.8",
     "@types/cookie-session": "^2.0.49",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",

--- a/infrastructure/k8s/tickets-depl.yaml
+++ b/infrastructure/k8s/tickets-depl.yaml
@@ -16,6 +16,14 @@ spec:
         - name: tickets
           image: us.gcr.io/eventhive-dev/tickets
           env:
+            - name: NATS_CLIENT_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NATS_URL
+              value: http://nats-streaming-srv:4222
+            - name: NATS_CLUSTER_ID
+              value: eventhive-nats
             - name: MONGO_URI
               value: mongodb://tickets-mongo-srv:27017/tickets
             - name: JWT_KEY

--- a/tickets/package-lock.json
+++ b/tickets/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@eventhive/common": "^1.0.6",
+        "@eventhive/common": "^1.0.8",
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
@@ -20,6 +20,7 @@
         "express-validator": "^7.2.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.7.2",
+        "node-nats-streaming": "^0.3.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.6.3"
       },
@@ -692,9 +693,9 @@
       }
     },
     "node_modules/@eventhive/common": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.6.tgz",
-      "integrity": "sha512-1HgEURHUc8ASXogLM2ANuO3RfJIuMyDXkuaOFyMNsnbGWdMA56o+T/nMUq3HNhUYoxtMYnsdbWSLg4CWGteJLg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.8.tgz",
+      "integrity": "sha512-GNKO9pUsmYQfUfd4ZtiB/WshnJKtOQWBm8cnvXzek1UB/9HWW/RM1zYh7fqKZPqPFR8ECZveIUDlot6i+90hag==",
       "dependencies": {
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",

--- a/tickets/package.json
+++ b/tickets/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@eventhive/common": "^1.0.6",
+    "@eventhive/common": "^1.0.8",
     "@types/cookie-session": "^2.0.49",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",
@@ -29,6 +29,7 @@
     "express-validator": "^7.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.7.2",
+    "node-nats-streaming": "^0.3.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.3"
   },

--- a/tickets/src/__mocks__/nats-wrapper.ts
+++ b/tickets/src/__mocks__/nats-wrapper.ts
@@ -1,0 +1,7 @@
+export const natsWrapper = {
+  client: {
+    publich: (subject: string, data: string, callback: () => void) => {
+      callback();
+    },
+  },
+};

--- a/tickets/src/__mocks__/nats-wrapper.ts
+++ b/tickets/src/__mocks__/nats-wrapper.ts
@@ -1,7 +1,11 @@
 export const natsWrapper = {
   client: {
-    publich: (subject: string, data: string, callback: () => void) => {
-      callback();
-    },
+    publish: jest
+      .fn()
+      .mockImplementation(
+        (subject: string, data: string, callback: () => void) => {
+          callback();
+        }
+      ),
   },
 };

--- a/tickets/src/events/publishers/ticket-created-publisher.ts
+++ b/tickets/src/events/publishers/ticket-created-publisher.ts
@@ -1,0 +1,5 @@
+import { Publisher, Subjects, TicketCreatedEvent } from "@eventhive/common";
+
+export class TicketCreatedPublisher extends Publisher<TicketCreatedEvent> {
+  readonly subject = Subjects.TicketCreated;
+}

--- a/tickets/src/events/publishers/ticket-updated-publisher.ts
+++ b/tickets/src/events/publishers/ticket-updated-publisher.ts
@@ -1,0 +1,5 @@
+import { Publisher, Subjects, TicketUpdatedEvent } from "@eventhive/common";
+
+export class TicketUpdatedPublisher extends Publisher<TicketUpdatedEvent> {
+  readonly subject = Subjects.TicketUpdated;
+}

--- a/tickets/src/index.ts
+++ b/tickets/src/index.ts
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import { app } from "./app";
+import { natsWrapper } from "./nats-wrapper";
 
 const start = async () => {
   if (!process.env.JWT_KEY) {
@@ -11,6 +12,17 @@ const start = async () => {
   }
 
   try {
+    await natsWrapper.connect(
+      "eventhive-nats",
+      "tickets-service",
+      "http://nats-streaming-srv:4222"
+    );
+    natsWrapper.client.on("close", () => {
+      console.log("NATS connection closed");
+      process.exit();
+    });
+    process.on("SIGINT", () => natsWrapper.client.close());
+    process.on("SIGTERM", () => natsWrapper.client.close());
     await mongoose.connect(process.env.MONGO_URI);
     console.log("Tickets Service: Connected to MongoDB");
   } catch (err) {

--- a/tickets/src/index.ts
+++ b/tickets/src/index.ts
@@ -11,11 +11,23 @@ const start = async () => {
     throw new Error("MONGO_URI must be defined");
   }
 
+  if (!process.env.NATS_CLIENT_ID) {
+    throw new Error("NATS_CLIENT_ID must be defined");
+  }
+
+  if (!process.env.NATS_URL) {
+    throw new Error("NATS_URL must be defined");
+  }
+
+  if (!process.env.NATS_CLUSTER_ID) {
+    throw new Error("NATS_CLUSTER_ID must be defined");
+  }
+
   try {
     await natsWrapper.connect(
-      "eventhive-nats",
-      "tickets-service",
-      "http://nats-streaming-srv:4222"
+      process.env.NATS_CLUSTER_ID,
+      process.env.NATS_CLIENT_ID,
+      process.env.NATS_URL
     );
     natsWrapper.client.on("close", () => {
       console.log("NATS connection closed");

--- a/tickets/src/nats-wrapper.ts
+++ b/tickets/src/nats-wrapper.ts
@@ -1,0 +1,30 @@
+import nats, { Stan } from "node-nats-streaming";
+
+class NatsWrapper {
+  private _client?: Stan;
+
+  get client() {
+    if (!this._client) {
+      throw new Error("NATS client not initialized");
+    }
+    return this._client;
+  }
+
+  connect(clusterId: string, clientId: string, url: string) {
+    this._client = nats.connect(clusterId, clientId, { url });
+
+    return new Promise<void>((resolve, reject) => {
+      this.client.on("connect", () => {
+        console.log("Connected to NATS");
+        resolve();
+      });
+
+      this.client.on("error", (err) => {
+        console.error(err);
+        reject(err);
+      });
+    });
+  }
+}
+
+export const natsWrapper = new NatsWrapper();

--- a/tickets/src/routes/__test__/new.test.ts
+++ b/tickets/src/routes/__test__/new.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { app } from "../../app";
 import { Ticket } from "../../models/ticket";
+import { natsWrapper } from "../../nats-wrapper";
 
 it("route handler at /api/tickets for POST exists", async () => {
   const response = await request(app).post("/api/tickets").send({});
@@ -72,4 +73,23 @@ it("creates a ticket with valid input", async () => {
   expect(tickets.length).toEqual(1);
   expect(tickets[0].price).toEqual(price);
   expect(tickets[0].title).toEqual(title);
+});
+
+it("publishes an event", async () => {
+  const title = "test";
+  const price = 20;
+
+  let tickets = await Ticket.find({});
+  expect(tickets.length).toEqual(0);
+
+  await request(app)
+    .post("/api/tickets")
+    .set("Cookie", global.signup())
+    .send({
+      title,
+      price,
+    })
+    .expect(201);
+
+  expect(natsWrapper.client.publish).toHaveBeenCalled();
 });

--- a/tickets/src/routes/__test__/update.test.ts
+++ b/tickets/src/routes/__test__/update.test.ts
@@ -2,6 +2,7 @@ import request from "supertest";
 import { app } from "../../app";
 import mongoose from "mongoose";
 import { Ticket } from "../../models/ticket";
+import { natsWrapper } from "../../nats-wrapper";
 
 it("returns a 404 if the provided id does not exist", async () => {
   const id = new mongoose.Types.ObjectId().toHexString();
@@ -107,4 +108,26 @@ it("updates ticket on valid input", async () => {
 
   expect(ticketResponse.body.title).toEqual("title2");
   expect(ticketResponse.body.price).toEqual(30);
+});
+
+it("publishes an event", async () => {
+  const cookie = global.signup();
+  const response = await request(app)
+    .post(`/api/tickets`)
+    .set("Cookie", cookie)
+    .send({
+      title: "title",
+      price: 20,
+    });
+
+  await request(app)
+    .put(`/api/tickets/${response.body.id}`)
+    .set("Cookie", cookie)
+    .send({
+      title: "title2",
+      price: 30,
+    })
+    .expect(200);
+
+  expect(natsWrapper.client.publish).toHaveBeenCalled();
 });

--- a/tickets/src/routes/new.ts
+++ b/tickets/src/routes/new.ts
@@ -2,6 +2,8 @@ import express, { Request, Response } from "express";
 import { requireAuth, validateRequest } from "@eventhive/common";
 import { body } from "express-validator";
 import { Ticket } from "../models/ticket";
+import { TicketCreatedPublisher } from "../events/publishers/ticket-created-publisher";
+import { natsWrapper } from "../nats-wrapper";
 
 const router = express.Router();
 
@@ -25,6 +27,13 @@ router.post(
     });
 
     await ticket.save();
+
+    await new TicketCreatedPublisher(natsWrapper.client).publish({
+      id: ticket.id,
+      title: ticket.title,
+      price: ticket.price,
+      userId: ticket.userId,
+    });
 
     res.status(201).send(ticket);
   }

--- a/tickets/src/routes/update.ts
+++ b/tickets/src/routes/update.ts
@@ -7,6 +7,8 @@ import {
   requireAuth,
   NotAuthorizedError,
 } from "@eventhive/common";
+import { TicketUpdatedPublisher } from "../events/publishers/ticket-updated-publisher";
+import { natsWrapper } from "../nats-wrapper";
 
 const router = express.Router();
 
@@ -36,6 +38,13 @@ router.put(
       price: req.body.price,
     });
     await ticket.save();
+
+    await new TicketUpdatedPublisher(natsWrapper.client).publish({
+      id: ticket.id,
+      title: ticket.title,
+      price: ticket.price,
+      userId: ticket.userId,
+    });
 
     res.send(ticket);
   }

--- a/tickets/src/test/setup.ts
+++ b/tickets/src/test/setup.ts
@@ -4,6 +4,8 @@ import { app } from "../app";
 import request from "supertest";
 import jwt from "jsonwebtoken";
 
+jest.mock("../nats-wrapper");
+
 let mongo: MongoMemoryServer;
 
 declare global {


### PR DESCRIPTION
As learnt in the nats streaming server test setup:
- We needed to consistently connect to nats streaming server through a client.
- In this review we setted up the client in tickets service and fixed the failing tests.
- We mocked this singleton client for the service using jest mock up
- Published the ticket created event.