### PR TITLE
012 listening events

### DIFF
--- a/orders/package-lock.json
+++ b/orders/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@eventhive/common": "^1.0.11",
+        "@eventhive/common": "^1.0.12",
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
@@ -694,9 +694,9 @@
       }
     },
     "node_modules/@eventhive/common": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.11.tgz",
-      "integrity": "sha512-TuBKvF8y1kJbqXfQlY9DoS/5BwOXiGB69DX+e4kSTUQEVen4Gmrxz3ZG1NhbBs/ZrtL5qEtyUQ2yG1ng/KYKQQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.12.tgz",
+      "integrity": "sha512-HtPsQXZO9IeR8Y026PTXOu4v9m3GT/4+7SfPEGRbvzqMlFkaRt7+VK5iubUnNFPICe0BC+HzgfnNwGLzDhy96w==",
       "dependencies": {
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",

--- a/orders/package-lock.json
+++ b/orders/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@eventhive/common": "^1.0.10",
+        "@eventhive/common": "^1.0.11",
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
@@ -20,6 +20,7 @@
         "express-validator": "^7.2.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.7.2",
+        "mongoose-update-if-current": "^1.4.0",
         "node-nats-streaming": "^0.3.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.6.3"
@@ -693,9 +694,9 @@
       }
     },
     "node_modules/@eventhive/common": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.10.tgz",
-      "integrity": "sha512-j7KNde1QHDdCvuNhpg6USn/p/5gynm9novhZZ7n/FpcwA8yf4CMHkz7NziSmJ+jgmaG/qj3RmjkS6CHiXOcYAA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.11.tgz",
+      "integrity": "sha512-TuBKvF8y1kJbqXfQlY9DoS/5BwOXiGB69DX+e4kSTUQEVen4Gmrxz3ZG1NhbBs/ZrtL5qEtyUQ2yG1ng/KYKQQ==",
       "dependencies": {
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",
@@ -2157,6 +2158,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
+      "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/create-jest": {
@@ -4379,6 +4390,22 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
+    "node_modules/mongoose-update-if-current": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mongoose-update-if-current/-/mongoose-update-if-current-1.4.0.tgz",
+      "integrity": "sha512-Rau2nvdiLExqXrSOwMMgDYQgf/fwTJQpPidTcT7C9UMQ282gTKXjDuh5vrjVvVQpfuvkiPis0tGHdXffaD54bg==",
+      "dependencies": {
+        "core-js": "^3.2.1",
+        "kareem": "^2.3.0",
+        "regenerator-runtime": "^0.13.5"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "mongoose": ">=5.0.0"
+      }
+    },
     "node_modules/mongoose/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4896,6 +4923,11 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/orders/package.json
+++ b/orders/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@eventhive/common": "^1.0.11",
+    "@eventhive/common": "^1.0.12",
     "@types/cookie-session": "^2.0.49",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",

--- a/orders/package.json
+++ b/orders/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@eventhive/common": "^1.0.10",
+    "@eventhive/common": "^1.0.11",
     "@types/cookie-session": "^2.0.49",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",
@@ -29,6 +29,7 @@
     "express-validator": "^7.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.7.2",
+    "mongoose-update-if-current": "^1.4.0",
     "node-nats-streaming": "^0.3.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.3"

--- a/orders/src/events/listeners/__test__/ticket-created-listener.test.ts
+++ b/orders/src/events/listeners/__test__/ticket-created-listener.test.ts
@@ -1,0 +1,47 @@
+import { TicketCreatedListener } from "../ticket-created-listener";
+import { natsWrapper } from "../../../nats-wrapper";
+import { TicketCreatedEvent } from "@eventhive/common";
+import mongoose from "mongoose";
+import { Message } from "node-nats-streaming";
+import { Ticket } from "../../../models/ticket";
+
+const setup = async () => {
+  // create an instance of the listener
+  const listener = new TicketCreatedListener(natsWrapper.client);
+  // create a fake data event
+  const data: TicketCreatedEvent["data"] = {
+    version: 0,
+    id: new mongoose.Types.ObjectId().toHexString(),
+    title: "concert",
+    price: 10,
+    userId: new mongoose.Types.ObjectId().toHexString(),
+  };
+  // create a fake message object
+  // @ts-ignore
+  const msg: Message = {
+    ack: jest.fn(),
+  };
+  // return all of this stuff
+
+  return { listener, data, msg };
+};
+
+it("creates and saves a ticket", async () => {
+  const { listener, data, msg } = await setup();
+
+  // call the onMessage function with the data object + message object
+  await listener.onMessage(data, msg);
+  // write assertions to make sure a ticket was created
+  const ticket = await Ticket.findById(data.id);
+  expect(ticket).toBeDefined();
+  expect(ticket!.title).toEqual(data.title);
+  expect(ticket!.price).toEqual(data.price);
+});
+
+it("acks the message", async () => {
+  const { listener, data, msg } = await setup();
+  // call the onMessage function with the data object + message object
+  await listener.onMessage(data, msg);
+  // write assertions to make sure ack function is called
+  expect(msg.ack).toHaveBeenCalled();
+});

--- a/orders/src/events/listeners/__test__/ticket-updated-listner.test.ts
+++ b/orders/src/events/listeners/__test__/ticket-updated-listner.test.ts
@@ -1,0 +1,61 @@
+import { natsWrapper } from "../../../nats-wrapper";
+import { TicketUpdatedListener } from "../ticket-updated-listener";
+import { TicketUpdatedEvent } from "@eventhive/common";
+import mongoose from "mongoose";
+import { Ticket } from "../../../models/ticket";
+import { Message } from "node-nats-streaming";
+
+const setup = async () => {
+  // Create a listener
+  const listner = new TicketUpdatedListener(natsWrapper.client);
+  // Create and save a ticket
+  const ticket = Ticket.build({
+    id: new mongoose.Types.ObjectId().toHexString(),
+    title: "concert",
+    price: 20,
+  });
+  await ticket.save();
+  // Create a fake data event
+  const data: TicketUpdatedEvent["data"] = {
+    id: ticket.id,
+    version: ticket.version + 1,
+    title: "concert updated",
+    price: 30,
+    userId: new mongoose.Types.ObjectId().toHexString(),
+  };
+  // Create a fake message object
+  // @ts-ignore
+  const msg: Message = {
+    ack: jest.fn(),
+  };
+  // Return all of this stuff
+  return { listner, ticket, data, msg };
+};
+
+it("finds, updates, and saves a ticket", async () => {
+  const { listner, ticket, data, msg } = await setup();
+  // Call the onMessage function with the data object + message object
+  await listner.onMessage(data, msg);
+  // Write assertions to make sure a ticket was updated
+  const updatedTicket = await Ticket.findById(ticket.id);
+  expect(updatedTicket!.title).toEqual(data.title);
+  expect(updatedTicket!.price).toEqual(data.price);
+  expect(updatedTicket!.version).toEqual(data.version);
+});
+
+it("acks the message", async () => {
+  const { listner, data, msg } = await setup();
+  // Call the onMessage function with the data object + message object
+  await listner.onMessage(data, msg);
+  // Write assertions to make sure ack function is called
+  expect(msg.ack).toHaveBeenCalled();
+});
+
+it("does not call ack if the event has a skipped version number", async () => {
+  const { listner, data, msg } = await setup();
+  data.version = 10;
+  try {
+    await listner.onMessage(data, msg);
+  } catch (err) {}
+  expect(msg.ack).not.toHaveBeenCalled();
+});

--- a/orders/src/events/listeners/queue-group-name.ts
+++ b/orders/src/events/listeners/queue-group-name.ts
@@ -1,0 +1,1 @@
+export const queueGroupName = "orders-service";

--- a/orders/src/events/listeners/ticket-created-listener.ts
+++ b/orders/src/events/listeners/ticket-created-listener.ts
@@ -1,0 +1,19 @@
+import { Message } from "node-nats-streaming";
+import { Subjects, TicketCreatedEvent, Listener } from "@eventhive/common";
+import { Ticket } from "../../models/ticket";
+import { queueGroupName } from "./queue-group-name";
+
+export class TicketCreatedListner extends Listener<TicketCreatedEvent> {
+  readonly subject = Subjects.TicketCreated;
+  queueGroupName = queueGroupName;
+  async onMessage(data: TicketCreatedEvent["data"], msg: Message) {
+    const { id, title, price } = data;
+    const ticket = Ticket.build({
+      id,
+      title,
+      price,
+    });
+    await ticket.save();
+    msg.ack();
+  }
+}

--- a/orders/src/events/listeners/ticket-created-listener.ts
+++ b/orders/src/events/listeners/ticket-created-listener.ts
@@ -3,7 +3,7 @@ import { Subjects, TicketCreatedEvent, Listener } from "@eventhive/common";
 import { Ticket } from "../../models/ticket";
 import { queueGroupName } from "./queue-group-name";
 
-export class TicketCreatedListner extends Listener<TicketCreatedEvent> {
+export class TicketCreatedListener extends Listener<TicketCreatedEvent> {
   readonly subject = Subjects.TicketCreated;
   queueGroupName = queueGroupName;
   async onMessage(data: TicketCreatedEvent["data"], msg: Message) {

--- a/orders/src/events/listeners/ticket-updated-listener.ts
+++ b/orders/src/events/listeners/ticket-updated-listener.ts
@@ -1,0 +1,20 @@
+import { Message } from "node-nats-streaming";
+import { Subjects, TicketUpdatedEvent, Listener } from "@eventhive/common";
+import { Ticket } from "../../models/ticket";
+import { queueGroupName } from "./queue-group-name";
+
+export class TicketUpdatedListener extends Listener<TicketUpdatedEvent> {
+  readonly subject = Subjects.TicketUpdated;
+  queueGroupName = queueGroupName;
+  async onMessage(data: TicketUpdatedEvent["data"], msg: Message) {
+    const ticket = await Ticket.findById(data.id);
+    if (!ticket) {
+      throw new Error("Ticket not found");
+    }
+
+    const { title, price } = data;
+    ticket.set({ title, price });
+    await ticket.save();
+    msg.ack();
+  }
+}

--- a/orders/src/events/listeners/ticket-updated-listener.ts
+++ b/orders/src/events/listeners/ticket-updated-listener.ts
@@ -7,7 +7,7 @@ export class TicketUpdatedListener extends Listener<TicketUpdatedEvent> {
   readonly subject = Subjects.TicketUpdated;
   queueGroupName = queueGroupName;
   async onMessage(data: TicketUpdatedEvent["data"], msg: Message) {
-    const ticket = await Ticket.findById(data.id);
+    const ticket = await Ticket.findByEvent(data);
     if (!ticket) {
       throw new Error("Ticket not found");
     }

--- a/orders/src/index.ts
+++ b/orders/src/index.ts
@@ -1,6 +1,8 @@
 import mongoose from "mongoose";
 import { app } from "./app";
 import { natsWrapper } from "./nats-wrapper";
+import { TicketCreatedListner } from "./events/listeners/ticket-created-listener";
+import { TicketUpdatedListener } from "./events/listeners/ticket-updated-listener";
 
 const start = async () => {
   if (!process.env.JWT_KEY) {
@@ -35,6 +37,10 @@ const start = async () => {
     });
     process.on("SIGINT", () => natsWrapper.client.close());
     process.on("SIGTERM", () => natsWrapper.client.close());
+
+    new TicketCreatedListner(natsWrapper.client).listen();
+    new TicketUpdatedListener(natsWrapper.client).listen();
+
     await mongoose.connect(process.env.MONGO_URI);
     console.log("Order Service: Connected to MongoDB");
   } catch (err) {

--- a/orders/src/index.ts
+++ b/orders/src/index.ts
@@ -1,7 +1,7 @@
 import mongoose from "mongoose";
 import { app } from "./app";
 import { natsWrapper } from "./nats-wrapper";
-import { TicketCreatedListner } from "./events/listeners/ticket-created-listener";
+import { TicketCreatedListener } from "./events/listeners/ticket-created-listener";
 import { TicketUpdatedListener } from "./events/listeners/ticket-updated-listener";
 
 const start = async () => {
@@ -38,7 +38,7 @@ const start = async () => {
     process.on("SIGINT", () => natsWrapper.client.close());
     process.on("SIGTERM", () => natsWrapper.client.close());
 
-    new TicketCreatedListner(natsWrapper.client).listen();
+    new TicketCreatedListener(natsWrapper.client).listen();
     new TicketUpdatedListener(natsWrapper.client).listen();
 
     await mongoose.connect(process.env.MONGO_URI);

--- a/orders/src/models/order.ts
+++ b/orders/src/models/order.ts
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import { OrderStatus } from "@eventhive/common";
 import { TicketDocument } from "./ticket";
+import { updateIfCurrentPlugin } from "mongoose-update-if-current";
 
 interface OrderAttributes {
   userId: string;
@@ -14,6 +15,7 @@ interface OrderDocument extends mongoose.Document {
   status: OrderStatus;
   expiresAt: Date;
   ticket: TicketDocument;
+  version: number;
 }
 
 interface OrderModel extends mongoose.Model<OrderDocument> {
@@ -49,6 +51,9 @@ const orderSchema = new mongoose.Schema(
     },
   }
 );
+
+orderSchema.set("versionKey", "version");
+orderSchema.plugin(updateIfCurrentPlugin);
 
 orderSchema.statics.build = (attributes: OrderAttributes) => {
   return new Order(attributes);

--- a/orders/src/models/ticket.ts
+++ b/orders/src/models/ticket.ts
@@ -2,6 +2,7 @@ import mongoose from "mongoose";
 import { Order, OrderStatus } from "./order";
 
 interface TicketAttributes {
+  id: string;
   title: string;
   price: number;
 }
@@ -39,7 +40,11 @@ const ticketSchema = new mongoose.Schema(
 );
 
 ticketSchema.statics.build = (attributes: TicketAttributes) => {
-  return new Ticket(attributes);
+  return new Ticket({
+    _id: attributes.id,
+    title: attributes.title,
+    price: attributes.price,
+  });
 };
 
 ticketSchema.methods.isReserved = async function () {

--- a/orders/src/models/ticket.ts
+++ b/orders/src/models/ticket.ts
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import { Order, OrderStatus } from "./order";
+import { updateIfCurrentPlugin } from "mongoose-update-if-current";
 
 interface TicketAttributes {
   id: string;
@@ -10,11 +11,16 @@ interface TicketAttributes {
 export interface TicketDocument extends mongoose.Document {
   title: string;
   price: number;
+  version: number;
   isReserved(): Promise<boolean>;
 }
 
 interface TicketModel extends mongoose.Model<TicketDocument> {
   build(attributes: TicketAttributes): TicketDocument;
+  findByEvent(event: {
+    id: string;
+    version: number;
+  }): Promise<TicketDocument | null>;
 }
 
 const ticketSchema = new mongoose.Schema(
@@ -39,11 +45,21 @@ const ticketSchema = new mongoose.Schema(
   }
 );
 
+ticketSchema.set("versionKey", "version");
+ticketSchema.plugin(updateIfCurrentPlugin);
+
 ticketSchema.statics.build = (attributes: TicketAttributes) => {
   return new Ticket({
     _id: attributes.id,
     title: attributes.title,
     price: attributes.price,
+  });
+};
+
+ticketSchema.statics.findByEvent = (event: { id: string; version: number }) => {
+  return Ticket.findOne({
+    _id: event.id,
+    version: event.version - 1,
   });
 };
 

--- a/orders/src/routes/__test__/delete.test.ts
+++ b/orders/src/routes/__test__/delete.test.ts
@@ -3,9 +3,11 @@ import { app } from "../../app";
 import { Ticket } from "../../models/ticket";
 import { OrderStatus } from "../../models/order";
 import { natsWrapper } from "../../nats-wrapper";
+import mongoose from "mongoose";
 
 it("marks an order as cancelled", async () => {
   const ticket = Ticket.build({
+    id: new mongoose.Types.ObjectId().toHexString(),
     title: "concert",
     price: 20,
   });
@@ -35,6 +37,7 @@ it("marks an order as cancelled", async () => {
 
 it("emits an order cancelled event", async () => {
   const ticket = Ticket.build({
+    id: new mongoose.Types.ObjectId().toHexString(),
     title: "concert",
     price: 20,
   });

--- a/orders/src/routes/__test__/index.test.ts
+++ b/orders/src/routes/__test__/index.test.ts
@@ -2,9 +2,11 @@ import request from "supertest";
 import { app } from "../../app";
 import { Ticket } from "../../models/ticket";
 import { Order, OrderStatus } from "../../models/order";
+import mongoose from "mongoose";
 
 const buildTicket = async () => {
   const ticket = Ticket.build({
+    id: new mongoose.Types.ObjectId().toHexString(),
     title: "concert",
     price: 20,
   });

--- a/orders/src/routes/__test__/new.test.ts
+++ b/orders/src/routes/__test__/new.test.ts
@@ -19,6 +19,7 @@ it("returns an error if the ticket does not exist", async () => {
 
 it("returns an error if the ticket is already reserved", async () => {
   const ticket = Ticket.build({
+    id: new mongoose.Types.ObjectId().toHexString(),
     title: "concert",
     price: 20,
   });
@@ -43,6 +44,7 @@ it("returns an error if the ticket is already reserved", async () => {
 
 it("reserves a ticket", async () => {
   const ticket = Ticket.build({
+    id: new mongoose.Types.ObjectId().toHexString(),
     title: "concert",
     price: 20,
   });
@@ -59,6 +61,7 @@ it("reserves a ticket", async () => {
 
 it("emits an order created event", async () => {
   const ticket = Ticket.build({
+    id: new mongoose.Types.ObjectId().toHexString(),
     title: "concert",
     price: 20,
   });

--- a/orders/src/routes/__test__/show.test.ts
+++ b/orders/src/routes/__test__/show.test.ts
@@ -1,9 +1,11 @@
 import request from "supertest";
 import { app } from "../../app";
 import { Ticket } from "../../models/ticket";
+import mongoose from "mongoose";
 
 it("fetches the order", async () => {
   const ticket = Ticket.build({
+    id: new mongoose.Types.ObjectId().toHexString(),
     title: "concert",
     price: 20,
   });
@@ -35,6 +37,7 @@ it("returns an error on invalid order id", async () => {
 
 it("returns an error if one user tries to fetch another user's order", async () => {
   const ticket = Ticket.build({
+    id: new mongoose.Types.ObjectId().toHexString(),
     title: "concert",
     price: 20,
   });

--- a/orders/src/routes/delete.ts
+++ b/orders/src/routes/delete.ts
@@ -35,6 +35,7 @@ router.delete(
     // Publish an event saying that an order was cancelled
     await new OrderCancelledPublisher(natsWrapper.client).publish({
       id: order.id,
+      version: order.version,
       ticket: {
         id: order.ticket.id,
       },

--- a/orders/src/routes/new.ts
+++ b/orders/src/routes/new.ts
@@ -59,6 +59,7 @@ router.post(
     // Publish an event saying that an order was created
     await new OrderCreatedPublisher(natsWrapper.client).publish({
       id: order.id,
+      version: order.version,
       status: order.status,
       userId: order.userId,
       expiresAt: order.expiresAt.toISOString(),

--- a/tickets/package-lock.json
+++ b/tickets/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@eventhive/common": "^1.0.8",
+        "@eventhive/common": "^1.0.11",
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
@@ -20,6 +20,7 @@
         "express-validator": "^7.2.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.7.2",
+        "mongoose-update-if-current": "^1.4.0",
         "node-nats-streaming": "^0.3.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.6.3"
@@ -693,9 +694,9 @@
       }
     },
     "node_modules/@eventhive/common": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.8.tgz",
-      "integrity": "sha512-GNKO9pUsmYQfUfd4ZtiB/WshnJKtOQWBm8cnvXzek1UB/9HWW/RM1zYh7fqKZPqPFR8ECZveIUDlot6i+90hag==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.11.tgz",
+      "integrity": "sha512-TuBKvF8y1kJbqXfQlY9DoS/5BwOXiGB69DX+e4kSTUQEVen4Gmrxz3ZG1NhbBs/ZrtL5qEtyUQ2yG1ng/KYKQQ==",
       "dependencies": {
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",
@@ -2157,6 +2158,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
+      "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/create-jest": {
@@ -4379,6 +4390,22 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
+    "node_modules/mongoose-update-if-current": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mongoose-update-if-current/-/mongoose-update-if-current-1.4.0.tgz",
+      "integrity": "sha512-Rau2nvdiLExqXrSOwMMgDYQgf/fwTJQpPidTcT7C9UMQ282gTKXjDuh5vrjVvVQpfuvkiPis0tGHdXffaD54bg==",
+      "dependencies": {
+        "core-js": "^3.2.1",
+        "kareem": "^2.3.0",
+        "regenerator-runtime": "^0.13.5"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "mongoose": ">=5.0.0"
+      }
+    },
     "node_modules/mongoose/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4896,6 +4923,11 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/tickets/package-lock.json
+++ b/tickets/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@eventhive/common": "^1.0.11",
+        "@eventhive/common": "^1.0.12",
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
@@ -694,9 +694,9 @@
       }
     },
     "node_modules/@eventhive/common": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.11.tgz",
-      "integrity": "sha512-TuBKvF8y1kJbqXfQlY9DoS/5BwOXiGB69DX+e4kSTUQEVen4Gmrxz3ZG1NhbBs/ZrtL5qEtyUQ2yG1ng/KYKQQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@eventhive/common/-/common-1.0.12.tgz",
+      "integrity": "sha512-HtPsQXZO9IeR8Y026PTXOu4v9m3GT/4+7SfPEGRbvzqMlFkaRt7+VK5iubUnNFPICe0BC+HzgfnNwGLzDhy96w==",
       "dependencies": {
         "@types/cookie-session": "^2.0.49",
         "@types/express": "^5.0.0",

--- a/tickets/package.json
+++ b/tickets/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@eventhive/common": "^1.0.11",
+    "@eventhive/common": "^1.0.12",
     "@types/cookie-session": "^2.0.49",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",

--- a/tickets/package.json
+++ b/tickets/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@eventhive/common": "^1.0.8",
+    "@eventhive/common": "^1.0.11",
     "@types/cookie-session": "^2.0.49",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",
@@ -29,6 +29,7 @@
     "express-validator": "^7.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.7.2",
+    "mongoose-update-if-current": "^1.4.0",
     "node-nats-streaming": "^0.3.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.3"

--- a/tickets/src/events/listeners/__test__/order-cancelled-listener.test.ts
+++ b/tickets/src/events/listeners/__test__/order-cancelled-listener.test.ts
@@ -1,0 +1,42 @@
+import { OrderCancelledListener } from "../order-cancelled-listener";
+import { OrderCancelledEvent } from "@eventhive/common";
+import { natsWrapper } from "../../../nats-wrapper";
+import { Ticket } from "../../../models/ticket";
+import mongoose from "mongoose";
+import { Message } from "node-nats-streaming";
+
+const setup = async () => {
+  const listener = new OrderCancelledListener(natsWrapper.client);
+  const orderId = new mongoose.Types.ObjectId().toHexString();
+  const ticket = Ticket.build({
+    title: "concert",
+    price: 30,
+    userId: "userid",
+  });
+  ticket.set({ orderId });
+  await ticket.save();
+
+  const data: OrderCancelledEvent["data"] = {
+    id: orderId,
+    version: 0,
+    ticket: {
+      id: ticket.id,
+    },
+  };
+
+  // @ts-ignore
+  const msg: Message = {
+    ack: jest.fn(),
+  };
+
+  return { listener, ticket, data, msg };
+};
+
+it("updates the ticket, publishes an event, and acks the message", async () => {
+  const { listener, ticket, data, msg } = await setup();
+  await listener.onMessage(data, msg);
+  const updatedTicket = await Ticket.findById(ticket.id);
+  expect(updatedTicket!.orderId).not.toBeDefined();
+  expect(msg.ack).toHaveBeenCalled();
+  expect(natsWrapper.client.publish).toHaveBeenCalled();
+});

--- a/tickets/src/events/listeners/__test__/order-created-listener.test.ts
+++ b/tickets/src/events/listeners/__test__/order-created-listener.test.ts
@@ -1,0 +1,59 @@
+import { OrderCreatedListener } from "../order-created-listener";
+import { natsWrapper } from "../../../nats-wrapper";
+import { Ticket } from "../../../models/ticket";
+import { OrderCreatedEvent, OrderStatus } from "@eventhive/common";
+import mongoose from "mongoose";
+import { Message } from "node-nats-streaming";
+
+const setup = async () => {
+  const listener = new OrderCreatedListener(natsWrapper.client);
+  const ticket = Ticket.build({
+    title: "concert",
+    price: 30,
+    userId: "userid",
+  });
+  await ticket.save();
+
+  const data: OrderCreatedEvent["data"] = {
+    id: new mongoose.Types.ObjectId().toHexString(),
+    version: 0,
+    status: OrderStatus.Created,
+    userId: "userid",
+    expiresAt: "date",
+    ticket: {
+      id: ticket.id,
+      price: ticket.price,
+    },
+  };
+
+  // @ts-ignore
+  const msg: Message = {
+    ack: jest.fn(),
+  };
+
+  return { listener, ticket, data, msg };
+};
+
+it("sets the orderId of the ticket", async () => {
+  const { listener, ticket, data, msg } = await setup();
+  await listener.onMessage(data, msg);
+  const updatedTicket = await Ticket.findById(ticket.id);
+  expect(updatedTicket!.orderId).toEqual(data.id);
+});
+
+it("acks the message", async () => {
+  const { listener, data, msg } = await setup();
+  await listener.onMessage(data, msg);
+  expect(msg.ack).toHaveBeenCalled();
+});
+
+it("publishes a ticket updated event", async () => {
+  const { listener, ticket, data, msg } = await setup();
+  await listener.onMessage(data, msg);
+  expect(natsWrapper.client.publish).toHaveBeenCalled();
+  const ticketUpdatedData = JSON.parse(
+    (natsWrapper.client.publish as jest.Mock).mock.calls[2][1]
+  );
+  console.log((natsWrapper.client.publish as jest.Mock).mock.calls[2][1]);
+  expect(data.id).toEqual(ticketUpdatedData.orderId);
+});

--- a/tickets/src/events/listeners/order-cancelled-listener.ts
+++ b/tickets/src/events/listeners/order-cancelled-listener.ts
@@ -1,0 +1,29 @@
+import { Listener, Subjects, OrderCancelledEvent } from "@eventhive/common";
+import { queueGroupName } from "./queue-group-name";
+import { Message } from "node-nats-streaming";
+import { Ticket } from "../../models/ticket";
+import { TicketUpdatedPublisher } from "../publishers/ticket-updated-publisher";
+
+export class OrderCancelledListener extends Listener<OrderCancelledEvent> {
+  readonly subject = Subjects.OrderCancelled;
+  queueGroupName = queueGroupName;
+
+  async onMessage(data: OrderCancelledEvent["data"], msg: Message) {
+    const ticket = await Ticket.findById(data.ticket.id);
+    if (!ticket) {
+      throw new Error("Ticket not found");
+    }
+
+    ticket.set({ orderId: undefined });
+    await ticket.save();
+    await new TicketUpdatedPublisher(this.client).publish({
+      id: ticket.id,
+      price: ticket.price,
+      title: ticket.title,
+      userId: ticket.userId,
+      orderId: ticket.orderId,
+      version: ticket.version,
+    });
+    msg.ack();
+  }
+}

--- a/tickets/src/events/listeners/order-created-listener.ts
+++ b/tickets/src/events/listeners/order-created-listener.ts
@@ -1,0 +1,34 @@
+import {
+  Listener,
+  Subjects,
+  OrderCreatedEvent,
+  OrderStatus,
+} from "@eventhive/common";
+import { queueGroupName } from "./queue-group-name";
+import { Message } from "node-nats-streaming";
+import { Ticket } from "../../models/ticket";
+import { TicketUpdatedPublisher } from "../publishers/ticket-updated-publisher";
+
+export class OrderCreatedListener extends Listener<OrderCreatedEvent> {
+  readonly subject = Subjects.OrderCreated;
+  queueGroupName = queueGroupName;
+
+  async onMessage(data: OrderCreatedEvent["data"], msg: Message) {
+    const ticket = await Ticket.findById(data.ticket.id);
+    if (!ticket) {
+      throw new Error("Ticket not found");
+    }
+
+    ticket.set({ orderId: data.id });
+    await ticket.save();
+    await new TicketUpdatedPublisher(this.client).publish({
+      id: ticket.id,
+      price: ticket.price,
+      title: ticket.title,
+      userId: ticket.userId,
+      orderId: ticket.orderId,
+      version: ticket.version,
+    });
+    msg.ack();
+  }
+}

--- a/tickets/src/events/listeners/queue-group-name.ts
+++ b/tickets/src/events/listeners/queue-group-name.ts
@@ -1,0 +1,1 @@
+export const queueGroupName = "tickets-service";

--- a/tickets/src/index.ts
+++ b/tickets/src/index.ts
@@ -1,6 +1,8 @@
 import mongoose from "mongoose";
 import { app } from "./app";
 import { natsWrapper } from "./nats-wrapper";
+import { OrderCreatedListener } from "./events/listeners/order-created-listener";
+import { OrderCancelledListener } from "./events/listeners/order-cancelled-listener";
 
 const start = async () => {
   if (!process.env.JWT_KEY) {
@@ -35,6 +37,10 @@ const start = async () => {
     });
     process.on("SIGINT", () => natsWrapper.client.close());
     process.on("SIGTERM", () => natsWrapper.client.close());
+
+    new OrderCreatedListener(natsWrapper.client).listen();
+    new OrderCancelledListener(natsWrapper.client).listen();
+
     await mongoose.connect(process.env.MONGO_URI);
     console.log("Tickets Service: Connected to MongoDB");
   } catch (err) {

--- a/tickets/src/models/__test__/ticket.test.ts
+++ b/tickets/src/models/__test__/ticket.test.ts
@@ -1,0 +1,47 @@
+import { Ticket } from "../ticket";
+
+it("implements optimistic concurrency control", async () => {
+  // Create an instance of a ticket
+  const ticket = Ticket.build({
+    title: "concert",
+    price: 5,
+    userId: "123",
+  });
+
+  // Save the ticket to the database
+  await ticket.save();
+
+  // Fetch the ticket twice
+  const firstInstance = await Ticket.findById(ticket.id);
+  const secondInstance = await Ticket.findById(ticket.id);
+
+  // Make two separate changes to the tickets we fetched
+  firstInstance!.set({ price: 10 });
+  secondInstance!.set({ price: 15 });
+
+  // Save the first fetched ticket
+  await firstInstance!.save();
+
+  // Save the second fetched ticket and expect an error
+  try {
+    await secondInstance!.save();
+  } catch (err) {
+    return;
+  }
+
+  throw new Error("Should not reach this point");
+});
+
+it("increments the version number on multiple saves", async () => {
+  const ticket = Ticket.build({
+    title: "concert",
+    price: 20,
+    userId: "123",
+  });
+  await ticket.save();
+  expect(ticket.version).toEqual(0);
+  await ticket.save();
+  expect(ticket.version).toEqual(1);
+  await ticket.save();
+  expect(ticket.version).toEqual(2);
+});

--- a/tickets/src/models/ticket.ts
+++ b/tickets/src/models/ticket.ts
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { updateIfCurrentPlugin } from "mongoose-update-if-current";
 
 interface TicketAttributes {
   title: string;
@@ -10,6 +11,7 @@ interface TicketDocument extends mongoose.Document {
   title: string;
   price: number;
   userId: string;
+  version: number;
 }
 
 interface TicketModel extends mongoose.Model<TicketDocument> {
@@ -40,6 +42,9 @@ const ticketSchema = new mongoose.Schema(
     },
   }
 );
+
+ticketSchema.set("versionKey", "version");
+ticketSchema.plugin(updateIfCurrentPlugin);
 
 ticketSchema.statics.build = (attributes: TicketAttributes) => {
   return new Ticket(attributes);

--- a/tickets/src/models/ticket.ts
+++ b/tickets/src/models/ticket.ts
@@ -12,6 +12,7 @@ interface TicketDocument extends mongoose.Document {
   price: number;
   userId: string;
   version: number;
+  orderId?: string;
 }
 
 interface TicketModel extends mongoose.Model<TicketDocument> {
@@ -31,6 +32,9 @@ const ticketSchema = new mongoose.Schema(
     userId: {
       type: String,
       required: true,
+    },
+    orderId: {
+      type: String,
     },
   },
   {

--- a/tickets/src/routes/__test__/update.test.ts
+++ b/tickets/src/routes/__test__/update.test.ts
@@ -131,3 +131,27 @@ it("publishes an event", async () => {
 
   expect(natsWrapper.client.publish).toHaveBeenCalled();
 });
+
+it("rejects updates if the ticket is reserved", async () => {
+  const cookie = global.signup();
+  const response = await request(app)
+    .post(`/api/tickets`)
+    .set("Cookie", cookie)
+    .send({
+      title: "title",
+      price: 20,
+    });
+
+  const ticket = await Ticket.findById(response.body.id);
+  ticket!.set({ orderId: new mongoose.Types.ObjectId().toHexString() });
+  await ticket!.save();
+
+  await request(app)
+    .put(`/api/tickets/${response.body.id}`)
+    .set("Cookie", cookie)
+    .send({
+      title: "title2",
+      price: 30,
+    })
+    .expect(400);
+});

--- a/tickets/src/routes/new.ts
+++ b/tickets/src/routes/new.ts
@@ -33,6 +33,7 @@ router.post(
       title: ticket.title,
       price: ticket.price,
       userId: ticket.userId,
+      version: ticket.version,
     });
 
     res.status(201).send(ticket);

--- a/tickets/src/routes/update.ts
+++ b/tickets/src/routes/update.ts
@@ -44,6 +44,7 @@ router.put(
       title: ticket.title,
       price: ticket.price,
       userId: ticket.userId,
+      version: ticket.version,
     });
 
     res.send(ticket);

--- a/tickets/src/routes/update.ts
+++ b/tickets/src/routes/update.ts
@@ -6,6 +6,7 @@ import {
   NotFoundError,
   requireAuth,
   NotAuthorizedError,
+  BadRequestError,
 } from "@eventhive/common";
 import { TicketUpdatedPublisher } from "../events/publishers/ticket-updated-publisher";
 import { natsWrapper } from "../nats-wrapper";
@@ -27,6 +28,10 @@ router.put(
 
     if (!ticket) {
       throw new NotFoundError();
+    }
+
+    if (ticket.orderId) {
+      throw new BadRequestError("Cannot edit a reserved ticket");
     }
 
     if (ticket.userId !== req.currentUser!.id) {


### PR DESCRIPTION
## Listening To Events

- Order service listens to ticket created and updated events.
- Based on that it updates its data replication schema of tickets.
- It uses this schema to get the reference and details of the mapping ticket for any order.
- We prefer this data replication cause here we can also fine grain on what information should we store from any event object as per our requirement.

## Versioning (Optimistic Concurrency Control):

- Concurrency was a major concern for the implementation of the different events, their capturing and the order in which they were processed.
- One approach for this is that we maintain a version on the data whenever it is updated or created. This version tracks on the different checkpoint values.
- We reject the events that are not in the next successive order for the previously processed version. The NATs server will take care of again publishing the event after some time and we hope that by then the in order requests will be processed.